### PR TITLE
Some more improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 scripts/register.sh
 vm
+clusters

--- a/config.yml
+++ b/config.yml
@@ -7,8 +7,8 @@ default:
   start: true
   tunnel: false
   template: rhel-server-7.8-x86_64-kvm.qcow2
-  numcpus: 1
-  memory: 512
+  numcpus: 2
+  memory: 1024
   pool: default
   diskthin: true
   disks:

--- a/config.yml
+++ b/config.yml
@@ -6,7 +6,7 @@ default:
   nested: true
   start: true
   tunnel: false
-  template: rhel-server-7.8-x86_64-kvm.qcow2
+  template: rhel-server-7.9-update-12-x86_64-kvm.qcow2
   numcpus: 2
   memory: 1024
   pool: default

--- a/config.yml
+++ b/config.yml
@@ -6,7 +6,7 @@ default:
   nested: true
   start: true
   tunnel: false
-  template: rhel-server-7.7-x86_64-kvm.qcow2
+  template: rhel-server-7.8-x86_64-kvm.qcow2
   numcpus: 1
   memory: 512
   pool: default

--- a/plans/openshift/files/ansible.cfg-3.10
+++ b/plans/openshift/files/ansible.cfg-3.10
@@ -1,0 +1,22 @@
+[defaults]
+inventory = hosts
+forks = 20 
+host_key_checking = False
+remote_user = cloud-user
+roles_path = roles/
+gathering = smart
+#fact_caching = jsonfile
+#fact_caching_connection = $HOME/ansible/facts
+#fact_caching_timeout = 600
+log_path = $HOME/ansible.log
+nocows = 1
+callback_whitelist = profile_tasks
+
+[privilege_escalation]
+become = True
+
+[ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o ServerAliveInterval=60
+control_path = %(directory)s/%%h-%%r
+pipelining = True 
+timeout = 10

--- a/plans/openshift/files/ansible.cfg-3.11
+++ b/plans/openshift/files/ansible.cfg-3.11
@@ -1,0 +1,22 @@
+[defaults]
+inventory = hosts
+forks = 20 
+host_key_checking = False
+remote_user = cloud-user
+roles_path = roles/
+gathering = smart
+#fact_caching = jsonfile
+#fact_caching_connection = $HOME/ansible/facts
+#fact_caching_timeout = 600
+log_path = $HOME/ansible.log
+nocows = 1
+callback_whitelist = profile_tasks
+
+[privilege_escalation]
+become = True
+
+[ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o ServerAliveInterval=60
+control_path = %(directory)s/%%h-%%r
+pipelining = True 
+timeout = 10

--- a/plans/openshift/files/ansible.cfg-3.3
+++ b/plans/openshift/files/ansible.cfg-3.3
@@ -1,0 +1,22 @@
+[defaults]
+inventory = hosts
+forks = 20 
+host_key_checking = False
+remote_user = cloud-user
+roles_path = roles/
+gathering = smart
+#fact_caching = jsonfile
+#fact_caching_connection = $HOME/ansible/facts
+#fact_caching_timeout = 600
+log_path = $HOME/ansible.log
+nocows = 1
+callback_whitelist = profile_tasks
+
+[privilege_escalation]
+become = True
+
+[ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o ServerAliveInterval=60
+control_path = %(directory)s/%%h-%%r
+pipelining = True 
+timeout = 10

--- a/plans/openshift/files/ansible.cfg-3.4
+++ b/plans/openshift/files/ansible.cfg-3.4
@@ -1,0 +1,22 @@
+[defaults]
+inventory = hosts
+forks = 20 
+host_key_checking = False
+remote_user = cloud-user
+roles_path = roles/
+gathering = smart
+#fact_caching = jsonfile
+#fact_caching_connection = $HOME/ansible/facts
+#fact_caching_timeout = 600
+log_path = $HOME/ansible.log
+nocows = 1
+callback_whitelist = profile_tasks
+
+[privilege_escalation]
+become = True
+
+[ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o ServerAliveInterval=60
+control_path = %(directory)s/%%h-%%r
+pipelining = True 
+timeout = 10

--- a/plans/openshift/files/ansible.cfg-3.5
+++ b/plans/openshift/files/ansible.cfg-3.5
@@ -1,0 +1,22 @@
+[defaults]
+inventory = hosts
+forks = 20 
+host_key_checking = False
+remote_user = cloud-user
+roles_path = roles/
+gathering = smart
+#fact_caching = jsonfile
+#fact_caching_connection = $HOME/ansible/facts
+#fact_caching_timeout = 600
+log_path = $HOME/ansible.log
+nocows = 1
+callback_whitelist = profile_tasks
+
+[privilege_escalation]
+become = True
+
+[ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o ServerAliveInterval=60
+control_path = %(directory)s/%%h-%%r
+pipelining = True 
+timeout = 10

--- a/plans/openshift/files/ansible.cfg-3.6
+++ b/plans/openshift/files/ansible.cfg-3.6
@@ -1,0 +1,22 @@
+[defaults]
+inventory = hosts
+forks = 20 
+host_key_checking = False
+remote_user = cloud-user
+roles_path = roles/
+gathering = smart
+#fact_caching = jsonfile
+#fact_caching_connection = $HOME/ansible/facts
+#fact_caching_timeout = 600
+log_path = $HOME/ansible.log
+nocows = 1
+callback_whitelist = profile_tasks
+
+[privilege_escalation]
+become = True
+
+[ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o ServerAliveInterval=60
+control_path = %(directory)s/%%h-%%r
+pipelining = True 
+timeout = 10

--- a/plans/openshift/files/ansible.cfg-3.7
+++ b/plans/openshift/files/ansible.cfg-3.7
@@ -1,0 +1,22 @@
+[defaults]
+inventory = hosts
+forks = 20 
+host_key_checking = False
+remote_user = cloud-user
+roles_path = roles/
+gathering = smart
+#fact_caching = jsonfile
+#fact_caching_connection = $HOME/ansible/facts
+#fact_caching_timeout = 600
+log_path = $HOME/ansible.log
+nocows = 1
+callback_whitelist = profile_tasks
+
+[privilege_escalation]
+become = True
+
+[ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o ServerAliveInterval=60
+control_path = %(directory)s/%%h-%%r
+pipelining = True 
+timeout = 10

--- a/plans/openshift/files/ansible.cfg-3.8
+++ b/plans/openshift/files/ansible.cfg-3.8
@@ -1,0 +1,22 @@
+[defaults]
+inventory = hosts
+forks = 20 
+host_key_checking = False
+remote_user = cloud-user
+roles_path = roles/
+gathering = smart
+#fact_caching = jsonfile
+#fact_caching_connection = $HOME/ansible/facts
+#fact_caching_timeout = 600
+log_path = $HOME/ansible.log
+nocows = 1
+callback_whitelist = profile_tasks
+
+[privilege_escalation]
+become = True
+
+[ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o ServerAliveInterval=60
+control_path = %(directory)s/%%h-%%r
+pipelining = True 
+timeout = 10

--- a/plans/openshift/files/ansible.cfg-3.9
+++ b/plans/openshift/files/ansible.cfg-3.9
@@ -1,0 +1,22 @@
+[defaults]
+inventory = hosts
+forks = 20 
+host_key_checking = False
+remote_user = cloud-user
+roles_path = roles/
+gathering = smart
+#fact_caching = jsonfile
+#fact_caching_connection = $HOME/ansible/facts
+#fact_caching_timeout = 600
+log_path = $HOME/ansible.log
+nocows = 1
+callback_whitelist = profile_tasks
+
+[privilege_escalation]
+become = True
+
+[ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o ServerAliveInterval=60
+control_path = %(directory)s/%%h-%%r
+pipelining = True 
+timeout = 10

--- a/plans/openshift/files/hosts-multi-node-3.11
+++ b/plans/openshift/files/hosts-multi-node-3.11
@@ -44,7 +44,11 @@ ansible_service_broker_install=false
 openshift_metrics_install_metrics=true
 openshift_metrics_server_install=true
 
-oreg_url=registry.access.redhat.com/openshift3/ose-${component}:${version}
+oreg_url={{ oreg_url }}
+{% if oreg_auth_user!='' and oreg_auth_password!='' -%}
+oreg_auth_user="{{ oreg_auth_user }}"
+oreg_auth_password="{{ oreg_auth_password }}"
+{%- endif %}
 
 {% if glusterfs -%}
 openshift_storage_glusterfs_namespace=app-storage

--- a/plans/openshift/files/hosts-multi-node-3.11
+++ b/plans/openshift/files/hosts-multi-node-3.11
@@ -14,6 +14,11 @@ ansible_become=true
 openshift_deployment_type=openshift-enterprise
 openshift_release=v3.11
 
+{% if errata!=version -%}
+openshift_image_tag=v{{ errata }}
+openshift_pkg_version=-{{ errata }}
+{%- endif %}
+
 openshift_disable_check=disk_availability,memory_availability
 
 openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider'}]

--- a/plans/openshift/files/hosts-multi-node-3.11
+++ b/plans/openshift/files/hosts-multi-node-3.11
@@ -48,7 +48,13 @@ oreg_url={{ oreg_url }}
 {% if oreg_auth_user!='' and oreg_auth_password!='' -%}
 oreg_auth_user="{{ oreg_auth_user }}"
 oreg_auth_password="{{ oreg_auth_password }}"
-{%- endif %}
+{% endif %}
+
+{% if masters >= 3 -%}
+openshift_loadbalancer_additional_frontends=[{"name":"router-http","mode":"tcp","options":["tcplog"],"binds":["*:80"],"default_backend":"router-http"},{"name":"router-https","mode":"tcp","options":["tcplog"],"binds":["*:443"],"default_backend":"router-https"}]
+openshift_loadbalancer_additional_backends=[{"name":"router-http","mode":"tcp","option":"tcplog","balance":"source","servers":[{"name":"{{ cluster_name }}-master01.{{ domain }}","address":"{{ cluster_name }}-master01.{{ domain }}:80","opts":"check"},{"name":"{{ cluster_name }}-master02.{{ domain }}","address":"{{ cluster_name }}-master02.{{ domain }}:80","opts":"check"},{"name":"{{ cluster_name }}-master03.{{ domain }}","address":"{{ cluster_name }}-master03.{{ domain }}:80","opts":"check"}]},{"name":"router-https","mode":"tcp","option":"tcplog","balance":"source","servers":[{"name":"{{ cluster_name }}-master01.{{ domain }}","address":"{{ cluster_name }}-master01.{{ domain }}:443","opts":"check"},{"name":"{{ cluster_name }}-master02.{{ domain }}","address":"{{ cluster_name }}-master02.{{ domain }}:443","opts":"check"},{"name":"{{ cluster_name }}-master03.{{ domain }}","address":"{{ cluster_name }}-master03.{{ domain }}:443","opts":"check"}]}]
+r_openshift_loadbalancer_os_firewall_allow=[{"service":"haproxy stats","port":"9000/tcp"},{"service":"haproxy balance","port":"8443/tcp"},{"service":"router-http","port":"80/tcp"},{"service":"router-https","port":"443/tcp"}]
+{% endif %}
 
 {% if glusterfs -%}
 openshift_storage_glusterfs_namespace=app-storage

--- a/plans/openshift/multi-node.yml
+++ b/plans/openshift/multi-node.yml
@@ -5,6 +5,7 @@ parameters:
  net: 'default'
  nodes: 2
  version: '3.11'
+ errata: '3.11'
  glusterfs: false
  glusterfs_disk: vdc
  rhel_template: 'rhel-server-7.8-x86_64-kvm.qcow2'

--- a/plans/openshift/multi-node.yml
+++ b/plans/openshift/multi-node.yml
@@ -7,7 +7,7 @@ parameters:
  version: '3.11'
  glusterfs: false
  glusterfs_disk: vdc
- rhel_template: 'rhel-server-7.6-x86_64-kvm.qcow2'
+ rhel_template: 'rhel-server-7.8-x86_64-kvm.qcow2'
  etcds: 0
  time_zone: 'UTC'
 

--- a/plans/openshift/multi-node.yml
+++ b/plans/openshift/multi-node.yml
@@ -26,6 +26,7 @@ parameters:
  nets:
   - {{ net }}
  pool: default
+ rhnregister: false
  scripts: 
   - ~/.kcli/scripts/register.sh
   - scripts/host-preparation.sh-{{ version }}
@@ -37,6 +38,7 @@ parameters:
  profile: {{ cluster_name }}-node
  numcpus: 2
  memory: 4096
+ rhnregister: false
  nets:
   - name: {{ net }}
     alias:
@@ -68,6 +70,7 @@ parameters:
  profile: {{ cluster_name }}-node
  numcpus: 4
  memory: 16384
+ rhnregister: false
  disks:
   - size: 60
   - size: 60
@@ -76,6 +79,7 @@ parameters:
 {% for node in range(0, nodes | int) %}
 {{ cluster_name }}-node0{{ node + 1 }}:
  profile: {{ cluster_name }}-node
+ rhnregister: false
  disks:
   - size: 60
   - size: 60

--- a/plans/openshift/multi-node.yml
+++ b/plans/openshift/multi-node.yml
@@ -11,6 +11,9 @@ parameters:
  rhel_template: 'rhel-server-7.8-x86_64-kvm.qcow2'
  etcds: 0
  time_zone: 'UTC'
+ oreg_url: 'registry.access.redhat.com/openshift3/ose-${component}:${version}'
+ oreg_auth_user: ''
+ oreg_auth_password: ''
 
 {{ cluster_name }}-node:
  type: profile

--- a/plans/openshift/multi-node.yml
+++ b/plans/openshift/multi-node.yml
@@ -55,6 +55,8 @@ parameters:
  files:
   - path: /root/hosts
     origin: files/hosts-multi-node-{{ version }}
+  - path: /root/ansible.cfg
+    origin: files/ansible.cfg-{{ version }}
 {% endfor %}
 
 {% for etcd in range(0, etcds | int) %}

--- a/plans/openshift/multi-node.yml
+++ b/plans/openshift/multi-node.yml
@@ -79,7 +79,7 @@ parameters:
  disks:
   - size: 60
   - size: 60
-{% if glusterfs -%}
+{% if glusterfs %}
   - size: 100
-{%- endif %}
+{% endif %}
 {% endfor %}

--- a/plans/openshift/multi-node.yml
+++ b/plans/openshift/multi-node.yml
@@ -8,7 +8,7 @@ parameters:
  errata: '3.11'
  glusterfs: false
  glusterfs_disk: vdc
- rhel_template: 'rhel-server-7.8-x86_64-kvm.qcow2'
+ rhel_template: 'rhel7'
  etcds: 0
  time_zone: 'UTC'
  oreg_url: 'registry.access.redhat.com/openshift3/ose-${component}:${version}'

--- a/plans/openshift/multi-node.yml
+++ b/plans/openshift/multi-node.yml
@@ -14,11 +14,13 @@ parameters:
  oreg_url: 'registry.access.redhat.com/openshift3/ose-${component}:${version}'
  oreg_auth_user: ''
  oreg_auth_password: ''
+ ssh_keys: []
 
 {{ cluster_name }}-node:
  type: profile
  template: {{ rhel_template }}
  numcpus: 4
+ keys: {{ ssh_keys }}
  memory: 8192
  sharedkey: True
  domain: {{ domain }}

--- a/plans/openshift/scripts/host-preparation-common.sh
+++ b/plans/openshift/scripts/host-preparation-common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-yum install -y vim screen tmux tcpdump nc socat sysstat rng-tools
+yum install -y vim screen tmux tcpdump nc socat sysstat rng-tools lsof
 
 systemctl enable rngd
 

--- a/plans/openshift/scripts/host-preparation.sh-3.11
+++ b/plans/openshift/scripts/host-preparation.sh-3.11
@@ -5,7 +5,7 @@ subscription-manager repos \
     --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
     --enable="rhel-7-server-ose-3.11-rpms" \
-    --enable="rhel-7-server-ansible-2.6-rpms"
+    --enable="rhel-7-server-ansible-2.9-rpms"
 
 # Update 
 yum update -y

--- a/plans/openshift/scripts/host-preparation.sh-3.11
+++ b/plans/openshift/scripts/host-preparation.sh-3.11
@@ -18,7 +18,12 @@ yum install -y openshift-ansible
 yum install -y docker-1.13.1
 
 # Configuring Docker Storage (Option A)
-echo DEVS=/dev/vdb >/etc/sysconfig/docker-storage-setup
+echo STORAGE_DRIVER=overlay2 > /etc/sysconfig/docker-storage-setup
+echo DEVS=/dev/vdb >>/etc/sysconfig/docker-storage-setup
 echo VG=docker-vg >>/etc/sysconfig/docker-storage-setup
-docker-storage-setup
+echo 'DATA_SIZE=99%VG' >>/etc/sysconfig/docker-storage-setup
+echo 'CONTAINER_ROOT_LV_NAME=docker-root-lv' >>/etc/sysconfig/docker-storage-setup
+echo 'CONTAINER_ROOT_LV_SIZE=100%FREE' >>/etc/sysconfig/docker-storage-setup
+echo 'CONTAINER_ROOT_LV_MOUNT_PATH=/var/lib/docker' >>/etc/sysconfig/docker-storage-setup
+container-storage-setup
 systemctl enable --now docker

--- a/plans/openshift/scripts/host-preparation.sh-3.11
+++ b/plans/openshift/scripts/host-preparation.sh-3.11
@@ -2,8 +2,10 @@
 
 # Enable repositories
 subscription-manager repos \
+    --disable="*"
     --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
+    --enable="rhel-7-server-optional-rpms" \
     --enable="rhel-7-server-ose-3.11-rpms" \
     --enable="rhel-7-server-ansible-2.9-rpms"
 

--- a/scripts/register.sh.sample
+++ b/scripts/register.sh.sample
@@ -1,4 +1,4 @@
 sleep $[ ( $RANDOM % 10 ) + 1 ]s
 subscription-manager register --force --username=<rhn_user> --password=<rhn_password>
-subscription-manager attach --pool=<employee_sku_pool_id>
+subscription-manager attach --pool=<sku_pool_id>
 subscription-manager repos --disable="*" --enable=rhel-7-server-rpms


### PR DESCRIPTION
Some more improvements:
- Latest 3.11 erratas recommend ansible 2.9
- RHEL7 default images upgraded to RHEL 7.8
- Added default `ansible.cfg` with all the recommendations from scaling guide with some slight differences (see commit description)
- Added explicit `/etc/sysconfig/docker-storage-setup` settings for overlay2 (otherwise, it would default to devicemapper). Only for 3.11 at the moment (but I guess it would work on 3.10 and 3.9 at least)